### PR TITLE
Added list of testers provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # libft42_testers
-a simple make file to download few testers for you :)<br><br>
+a simple make file to download few testers for you, testers so far include:<br>
+-War-Machine<br>
+-Troupoullie<br>
+-Unit-test<br>
+
+Please contact us if you wish a certain tester to be included, thank you for your collaboration in advance.:)<br><br>
 # Download Testers<br>
 <code>make war</code> : Downloads libft war machine<br>
 <code>make unit</code> : Downloads libft unit tester<br>


### PR DESCRIPTION
Included a list of **testers** that are currently provided within the makefile, also prompted any _viewers_ to suggest other testers to us.